### PR TITLE
Add create or update profile operation to klaviyo node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2
+- Added **Create or Update Profile** operation
+  - Uses Klaviyo’s new endpoint to create a profile if it doesn’t exist, or update it if it does
+  - No Klaviyo ID required
+  
+
 ## 0.4.1
 - Add API version 2025-07-15
 - Remove deprecated API versions

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 - Get One
 - Create
 - Update
+- Create or Update
 
 ### Templates
 - Create

--- a/nodes/Klaviyo/Profile.ts
+++ b/nodes/Klaviyo/Profile.ts
@@ -62,6 +62,17 @@ export const ProfileOperations: INodeProperties[] = [
 					},
 				},
 			},
+			{
+				name: 'Create or Update',
+				value: 'createOrUpdate',
+				action: 'Create or update a profile',
+				routing: {
+					request: {
+						method: 'POST',
+						url: '/profile-import',
+					},
+				},
+			},
 		],
 		default: 'getAll',
 	},
@@ -80,7 +91,7 @@ const createProfileFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['profile'],
-				operation: ['create']
+				operation: ['create','createOrUpdate']
 			},
 		},
 	},
@@ -93,7 +104,7 @@ const createProfileFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['profile'],
-				operation: ['create']
+				operation: ['create','createOrUpdate']
 			},
 		},
 		typeOptions: {


### PR DESCRIPTION
Adds the ability for using the Create or Update Profile Operation from Klaviyo (https://developers.klaviyo.com/en/reference/create_or_update_profile)

The difference this provides than the existing is the normal create profile operation requires the Klaviyo Reference ID, whereas this operation allows for providing either an External ID, Email or Phone Number instead which will create or update the Klaviyo profile based on whether it pre-exists.